### PR TITLE
Adjust streamly benchmarks. 

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -1,3 +1,8 @@
-# 0.1.0
+# 1.1.0
+
+* Add functions: `replicateConcurrently` and `replicateConcurrently_`
+
+
+# 1.0.0
 
 Initial release.

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -205,44 +205,188 @@ Benchmarked function is very simple, we simply `map` a `sum` function over a lis
 
 
 ```
-benchmarking Sums: 1000/unliftio/pooledMapConcurrently
-time                 57.60 ms   (56.28 ms .. 58.42 ms)
-                     0.999 R²   (0.997 R² .. 1.000 R²)
-mean                 56.40 ms   (54.90 ms .. 57.89 ms)
-std dev              2.696 ms   (1.725 ms .. 4.221 ms)
-variance introduced by outliers: 15% (moderately inflated)
+scheduler-1.0.1: benchmarks
+Running 1 benchmarks...
+Benchmark scheduler: RUNNING...
+benchmarking replicate/Fib(1000/10000)/scheduler/replicateConcurrently
+time                 11.25 ms   (10.01 ms .. 12.28 ms)
+                     0.945 R²   (0.908 R² .. 0.975 R²)
+mean                 10.82 ms   (10.18 ms .. 11.58 ms)
+std dev              1.861 ms   (1.291 ms .. 2.572 ms)
+variance introduced by outliers: 78% (severely inflated)
 
-benchmarking Sums: 1000/monad-par/parMapM
-time                 58.27 ms   (57.22 ms .. 59.13 ms)
-                     0.999 R²   (0.998 R² .. 1.000 R²)
-mean                 59.68 ms   (59.05 ms .. 60.94 ms)
-std dev              1.814 ms   (837.5 μs .. 2.646 ms)
+benchmarking replicate/Fib(1000/10000)/unliftio/pooledReplicateConcurrently
+time                 8.941 ms   (8.576 ms .. 9.197 ms)
+                     0.987 R²   (0.970 R² .. 0.995 R²)
+mean                 9.070 ms   (8.764 ms .. 9.561 ms)
+std dev              1.073 ms   (616.4 μs .. 1.606 ms)
+variance introduced by outliers: 64% (severely inflated)
 
-benchmarking Sums: 1000/scheduler/traverseConcurrently
-time                 60.76 ms   (59.81 ms .. 61.37 ms)
-                     1.000 R²   (0.999 R² .. 1.000 R²)
-mean                 60.69 ms   (60.16 ms .. 61.91 ms)
-std dev              1.255 ms   (421.4 μs .. 2.129 ms)
+benchmarking replicate/Fib(1000/10000)/streamly/replicateM
+time                 13.05 ms   (11.63 ms .. 14.31 ms)
+                     0.954 R²   (0.882 R² .. 0.994 R²)
+mean                 13.29 ms   (12.45 ms .. 14.80 ms)
+std dev              2.845 ms   (1.269 ms .. 4.753 ms)
+variance introduced by outliers: 84% (severely inflated)
 
-benchmarking Sums: 1000/async/mapConcurrently
-time                 96.35 ms   (94.71 ms .. 97.40 ms)
-                     1.000 R²   (0.999 R² .. 1.000 R²)
-mean                 96.59 ms   (95.40 ms .. 97.72 ms)
-std dev              1.923 ms   (1.215 ms .. 2.844 ms)
+benchmarking replicate/Fib(1000/10000)/async/replicateConcurrently
+time                 26.88 ms   (24.23 ms .. 29.38 ms)
+                     0.964 R²   (0.921 R² .. 0.988 R²)
+mean                 27.38 ms   (25.96 ms .. 29.06 ms)
+std dev              3.410 ms   (2.680 ms .. 4.651 ms)
+variance introduced by outliers: 54% (severely inflated)
 
-benchmarking Sums: 1000/base/traverse . par
-time                 86.63 ms   (77.73 ms .. 96.38 ms)
-                     0.981 R²   (0.967 R² .. 0.999 R²)
-mean                 78.41 ms   (75.96 ms .. 82.60 ms)
-std dev              5.374 ms   (2.328 ms .. 8.587 ms)
+benchmarking replicate/Fib(1000/10000)/monad-par/replicateM
+time                 32.28 ms   (30.29 ms .. 33.65 ms)
+                     0.991 R²   (0.981 R² .. 0.998 R²)
+mean                 34.14 ms   (32.75 ms .. 36.11 ms)
+std dev              3.570 ms   (2.009 ms .. 5.078 ms)
+variance introduced by outliers: 42% (moderately inflated)
+
+benchmarking replicate/Fib(1000/10000)/base/replicateM
+time                 45.04 ms   (41.14 ms .. 50.00 ms)
+                     0.976 R²   (0.960 R² .. 0.991 R²)
+mean                 37.27 ms   (34.92 ms .. 40.05 ms)
+std dev              4.984 ms   (4.274 ms .. 5.931 ms)
+variance introduced by outliers: 52% (severely inflated)
+
+benchmarking replicate/Sum(1000/1000)/scheduler/replicateConcurrently
+time                 17.34 ms   (16.68 ms .. 18.01 ms)
+                     0.995 R²   (0.991 R² .. 0.999 R²)
+mean                 19.49 ms   (18.75 ms .. 20.35 ms)
+std dev              1.913 ms   (1.319 ms .. 2.557 ms)
+variance introduced by outliers: 44% (moderately inflated)
+
+benchmarking replicate/Sum(1000/1000)/unliftio/pooledReplicateConcurrently
+time                 16.79 ms   (15.90 ms .. 17.43 ms)
+                     0.993 R²   (0.990 R² .. 0.997 R²)
+mean                 16.12 ms   (15.87 ms .. 16.64 ms)
+std dev              741.7 μs   (478.6 μs .. 1.083 ms)
+variance introduced by outliers: 16% (moderately inflated)
+
+benchmarking replicate/Sum(1000/1000)/streamly/replicateM
+time                 16.99 ms   (16.32 ms .. 17.60 ms)
+                     0.990 R²   (0.984 R² .. 0.995 R²)
+mean                 18.99 ms   (18.41 ms .. 19.63 ms)
+std dev              1.573 ms   (1.205 ms .. 2.370 ms)
+variance introduced by outliers: 39% (moderately inflated)
+
+benchmarking replicate/Sum(1000/1000)/async/replicateConcurrently
+time                 29.23 ms   (28.43 ms .. 30.26 ms)
+                     0.997 R²   (0.994 R² .. 0.999 R²)
+mean                 27.57 ms   (26.85 ms .. 28.19 ms)
+std dev              1.514 ms   (1.112 ms .. 1.928 ms)
+variance introduced by outliers: 21% (moderately inflated)
+
+benchmarking replicate/Sum(1000/1000)/monad-par/replicateM
+time                 58.24 ms   (56.32 ms .. 61.18 ms)
+                     0.997 R²   (0.994 R² .. 0.999 R²)
+mean                 60.01 ms   (59.18 ms .. 60.81 ms)
+std dev              1.359 ms   (961.7 μs .. 2.088 ms)
+
+benchmarking replicate/Sum(1000/1000)/base/replicateM
+time                 55.84 ms   (55.28 ms .. 56.08 ms)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 56.50 ms   (56.20 ms .. 57.01 ms)
+std dev              675.2 μs   (420.3 μs .. 893.8 μs)
+
+benchmarking map/Fib(2000)/scheduler/traverseConcurrently
+time                 13.59 ms   (12.70 ms .. 14.58 ms)
+                     0.978 R²   (0.963 R² .. 0.989 R²)
+mean                 13.89 ms   (13.33 ms .. 14.66 ms)
+std dev              1.594 ms   (1.131 ms .. 2.212 ms)
+variance introduced by outliers: 56% (severely inflated)
+
+benchmarking map/Fib(2000)/unliftio/pooledTraverseConcurrently
+time                 7.987 ms   (7.134 ms .. 8.638 ms)
+                     0.956 R²   (0.925 R² .. 0.982 R²)
+mean                 7.888 ms   (7.508 ms .. 8.551 ms)
+std dev              1.459 ms   (1.020 ms .. 2.173 ms)
+variance introduced by outliers: 81% (severely inflated)
+
+benchmarking map/Fib(2000)/streamly/mapM
+time                 19.11 ms   (16.77 ms .. 21.11 ms)
+                     0.941 R²   (0.882 R² .. 0.979 R²)
+mean                 22.59 ms   (20.54 ms .. 26.62 ms)
+std dev              6.343 ms   (1.834 ms .. 9.521 ms)
+variance introduced by outliers: 90% (severely inflated)
+
+benchmarking map/Fib(2000)/async/mapConcurrently
+time                 34.86 ms   (30.83 ms .. 38.22 ms)
+                     0.976 R²   (0.953 R² .. 0.993 R²)
+mean                 43.67 ms   (40.22 ms .. 51.87 ms)
+std dev              10.52 ms   (6.972 ms .. 14.64 ms)
+variance introduced by outliers: 79% (severely inflated)
+
+benchmarking map/Fib(2000)/par/mapM
+time                 8.682 ms   (7.618 ms .. 9.577 ms)
+                     0.942 R²   (0.924 R² .. 0.965 R²)
+mean                 8.424 ms   (8.052 ms .. 9.014 ms)
+std dev              1.182 ms   (982.7 μs .. 1.633 ms)
+variance introduced by outliers: 71% (severely inflated)
+
+benchmarking map/Fib(2000)/monad-par/mapM
+time                 33.07 ms   (31.00 ms .. 34.73 ms)
+                     0.987 R²   (0.973 R² .. 0.996 R²)
+mean                 37.42 ms   (36.11 ms .. 38.95 ms)
+std dev              3.231 ms   (2.093 ms .. 4.098 ms)
+variance introduced by outliers: 36% (moderately inflated)
+
+benchmarking map/Fib(2000)/base/mapM
+time                 26.74 ms   (25.07 ms .. 28.32 ms)
+                     0.987 R²   (0.977 R² .. 0.996 R²)
+mean                 30.41 ms   (28.86 ms .. 32.48 ms)
+std dev              4.134 ms   (2.797 ms .. 6.007 ms)
+variance introduced by outliers: 59% (severely inflated)
+
+benchmarking map/Sum(2000)/scheduler/traverseConcurrently
+time                 41.13 ms   (38.35 ms .. 43.63 ms)
+                     0.990 R²   (0.978 R² .. 0.997 R²)
+mean                 39.37 ms   (38.21 ms .. 40.45 ms)
+std dev              2.548 ms   (2.028 ms .. 4.232 ms)
 variance introduced by outliers: 19% (moderately inflated)
 
-benchmarking Sums: 1000/base/traverse . seq
-time                 387.5 ms   (325.4 ms .. 451.6 ms)
-                     0.996 R²   (0.987 R² .. 1.000 R²)
-mean                 445.7 ms   (416.9 ms .. 473.8 ms)
-std dev              32.93 ms   (27.12 ms .. 37.56 ms)
-variance introduced by outliers: 21% (moderately inflated)
+benchmarking map/Sum(2000)/unliftio/pooledTraverseConcurrently
+time                 30.85 ms   (29.73 ms .. 31.72 ms)
+                     0.996 R²   (0.991 R² .. 0.998 R²)
+mean                 34.01 ms   (33.24 ms .. 35.21 ms)
+std dev              2.182 ms   (1.629 ms .. 2.792 ms)
+variance introduced by outliers: 24% (moderately inflated)
+
+benchmarking map/Sum(2000)/streamly/mapM
+time                 40.59 ms   (39.14 ms .. 43.14 ms)
+                     0.992 R²   (0.984 R² .. 0.997 R²)
+mean                 38.08 ms   (36.46 ms .. 39.56 ms)
+std dev              2.947 ms   (2.174 ms .. 3.671 ms)
+variance introduced by outliers: 25% (moderately inflated)
+
+benchmarking map/Sum(2000)/async/mapConcurrently
+time                 57.13 ms   (52.84 ms .. 61.29 ms)
+                     0.991 R²   (0.986 R² .. 0.998 R²)
+mean                 52.29 ms   (51.04 ms .. 54.14 ms)
+std dev              2.822 ms   (2.102 ms .. 3.802 ms)
+variance introduced by outliers: 14% (moderately inflated)
+
+benchmarking map/Sum(2000)/par/mapM
+time                 79.09 ms   (72.89 ms .. 85.64 ms)
+                     0.982 R²   (0.961 R² .. 0.997 R²)
+mean                 63.74 ms   (59.19 ms .. 68.40 ms)
+std dev              8.610 ms   (7.269 ms .. 10.25 ms)
+variance introduced by outliers: 44% (moderately inflated)
+
+benchmarking map/Sum(2000)/monad-par/mapM
+time                 222.8 ms   (211.5 ms .. 233.7 ms)
+                     0.998 R²   (0.996 R² .. 1.000 R²)
+mean                 233.6 ms   (227.5 ms .. 236.6 ms)
+std dev              5.712 ms   (2.215 ms .. 8.599 ms)
+variance introduced by outliers: 14% (moderately inflated)
+
+benchmarking map/Sum(2000)/base/mapM
+time                 112.9 ms   (104.0 ms .. 118.4 ms)
+                     0.995 R²   (0.986 R² .. 1.000 R²)
+mean                 126.4 ms   (121.1 ms .. 132.3 ms)
+std dev              7.872 ms   (6.986 ms .. 8.336 ms)
+variance introduced by outliers: 12% (moderately inflated)
 ```
 
 ## Beware of Demons
@@ -250,4 +394,3 @@ variance introduced by outliers: 21% (moderately inflated)
 Any sort of concurrency primitives such as mutual exclusion, semaphores, etc. can easily lead to
 deadlocks, starvation and other common problems. Try to avoid them and be careful if you do end up
 using them.
-

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -33,7 +33,7 @@ mkSumBench n elts =
   -- , 
     env (pure elts) $ \x ->
       bgroup
-        ("Replicate Sums: " <> show x)
+        ("Replicate Sums: " <> show n)
         [ bench "scheduler/replicateConcurrently" $
           nfIO $ withScheduler Par $ \s -> replicateM_ n $ scheduleWork s (f [0 .. x])
         , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f [0 .. x]

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Control.Monad (void, replicateM_)
+import Control.Monad (replicateM_)
 import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)
 import Control.Monad.Par (parMapM, runParIO)
 import Control.Parallel (par)
@@ -39,7 +38,7 @@ mkSumBench n elts =
   , bgroup
       "NoList"
       [ bench "scheduler" $
-        nfIO $ withScheduler_ Par $ \s -> replicateM_ n $ scheduleWork s $ void $ f [0 .. elts]
+        nfIO $ withScheduler Par $ \s -> replicateM_ n $ scheduleWork s $ f [0 .. elts]
       , bench "streamly" $
         nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
       ]

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -4,92 +4,137 @@ import qualified Control.Concurrent.Async as A (mapConcurrently,
                                                 mapConcurrently_,
                                                 replicateConcurrently,
                                                 replicateConcurrently_)
-import Control.Monad (void, replicateM, replicateM_)
-import Control.Monad.Par (parMapM, runParIO)
+import Control.Monad (replicateM, replicateM_)
+import Control.Monad.Par (IVar, Par, get, newFull_, parMapM, runParIO)
 import Control.Parallel (par)
 import Control.Scheduler
 import Criterion.Main
 import Data.Foldable as F
+import Data.IORef
+import Fib
 import Streamly (asyncly)
 import qualified Streamly.Prelude as S
 import UnliftIO.Async (pooledMapConcurrently, pooledMapConcurrently_,
                        pooledReplicateConcurrently,
                        pooledReplicateConcurrently_)
-import Fib
 
 main :: IO ()
-main = defaultMain (mkSumBench 1000 100000)
+main = do
+  defaultMain ([mkFibBench n x | n <- [100], x <- [100]]) --, 1000, 10000], x <- [100, 1000, 10000]])
 
-mkSumBench :: Int -> Int -> [Benchmark]
-mkSumBench n elts
-    -- env (pure elts) $ \x ->
-  --     bgroup
-  --       ("Replicate Sums (fast): " <> show x)
-  --       [ bench "unliftio/pooledReplicateConcurrently" $
-  --         nfIO (pooledReplicateConcurrently n $ f [0 .. x])
-  --         --replicateConcurrently Par n $ f [0 .. x]
-  --       , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n $ f [0 .. x]
-  --       ]
-  -- ,
- =
-  [ env (pure f) $ \f' ->
-      bgroup
-        ("Replicate Sums: " <> show n)
-        [ bench "scheduler/replicateConcurrently" $
-          nfIO $ withScheduler_ Par $ \s -> replicateM_ n $ scheduleWork s $ f' [0 .. elts]
-        , bench "scheduler/replicateConcurrently" $
-          nfIO $ replicateConcurrently_ Par n (f' [0 .. elts])
-        , bench "streamly/replicateM" $
-          nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' [0 .. elts]
-        , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' [0 .. elts]
-        , bench "base/replicateM" $ nfIO $ replicateM n $ f' [0 .. elts]
-        ]
-  , env (pure fibM) $ \f' ->
-      bgroup
-        ("Fib: " <> show elts)
-        [ bench "scheduler/replicateConcurrently" $ nfIO $ replicateConcurrently Par n $ f' elts
-        , bench "streamly/replicateM" $ nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' elts
-        , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' elts
-        , bench "base/replicateM" $ nfIO $ replicateM n $ f' elts
-        ]
-  -- , bgroup
-  --     ("Replicate Discard Sums " <> show n)
-  --     [ bench "unliftio/pooledReplicateConcurrently_" $
-  --       nfIO (pooledReplicateConcurrently_ n $ f [0 .. elts])
-  --     , bench "scheduler/replicateConcurrently_" $
-  --       nfIO $ replicateConcurrently_ Par n $ f [0 .. elts]
-  --     , bench "monad-par/replicateM_" $ nfIO $ runParIO $ replicateM_ n $ f [0 .. elts]
-  --     , bench "async/replicateConcurrently_" $ nfIO $ A.replicateConcurrently_ n $ f [0 .. elts]
-  --     , bench "streamly/replicateM" $
-  --       nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
-  --     ]
-  , env (pure ls) $ \xs ->
-      bgroup
-        ("Sums: " <> show n)
-        [ bench "unliftio/pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)
-        , bench "monad-par/parMapM" $ nfIO (runParIO $ parMapM f xs)
-        , bench "scheduler/traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)
-        , bench "async/mapConcurrently" $ nfIO (A.mapConcurrently f xs)
-        , bench "parallel/traverse (par)" $ nfIO (traverse fpar xs)
-        , bench "base/traverse (seq)" $ nfIO (traverse f xs)
-        ]
-  , env (pure ls) $ \xs ->
-      bgroup
-        ("Discard Traverse Sums: " <> show n)
-        [ bgroup "unliftio" [bench "pooledMapConcurrently_" $ nfIO (pooledMapConcurrently_ f xs)]
-        , bgroup "scheduler" [bench "traverseConcurrently_" $ nfIO (traverseConcurrently_ Par f xs)]
-        , bgroup "async" [bench "mapConcurrently_" $ nfIO (A.mapConcurrently_ f xs)]
-        ]
-  ]
+mkFibBench ::
+     Int -- ^ Number of workers
+  -> Int -- ^ Fibbonacci number
+  -> Benchmark
+mkFibBench n x =
+  bgroup
+    ("Fib " <> show x)
+    [ bench ("unliftio/pooledReplicateConcurrently" ++ nStr) $
+      nfIO $ pooledReplicateConcurrently n (newIORef x >>= fibM)
+    , bench ("scheduler/replicateConcurrently" ++ nStr) $
+      nfIO $ replicateConcurrently Par n (newIORef x >>= fibM)
+    , bench ("streamly/replicateM" ++ nStr) $
+      nfIO $ S.runStream $ asyncly $ S.replicateM n (newIORef x >>= fibM)
+    , bench ("monad-par/replicateM" ++ nStr) $
+      nfIO $ runParIO $ replicateM n (newFull_ x >>= fibPar)
+    , bench ("async/replicateConcurrently" ++ nStr) $
+      nfIO $ A.replicateConcurrently n (newIORef x >>= fibM)
+    , bench ("base/replicateM" ++ nStr) $ nfIO $ replicateM n (newIORef x >>= fibM)
+    ]
   where
-    ls = replicate n [0 .. elts] :: [[Int]]
-    f xs =
-      let ys = F.foldl' (+) 0 xs
-       in ys `seq` pure ys
-    fpar xs =
-      let ys = F.foldl' (+) 0 xs
-       in ys `par` pure ys
-    fibM :: Int -> IO Integer
-    fibM x =
-      let y = fib $ toInteger x
-       in y `seq` pure y
+    nStr = " (" ++ show n ++ ")"
+    fibM :: IORef Int -> IO Integer
+    fibM xRef = do
+      x' <- readIORef xRef
+      let y = fib $ toInteger x'
+      y `seq` pure y
+    fibPar :: IVar Int -> Par Integer
+    fibPar ivar = do
+      x' <- get ivar
+      let y = fib $ toInteger x'
+      y `seq` pure y
+
+
+-- mkSumBench :: Int -> Int -> [Benchmark]
+-- mkSumBench n elts
+--     -- env (pure elts) $ \x ->
+--   --     bgroup
+--   --       ("Replicate Sums (fast): " <> show x)
+--   --       [ bench "unliftio/pooledReplicateConcurrently" $
+--   --         nfIO (pooledReplicateConcurrently n $ f [0 .. x])
+--   --         --replicateConcurrently Par n $ f [0 .. x]
+--   --       , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n $ f [0 .. x]
+--   --       ]
+--   -- ,
+--  =
+--   [ env (pure f) $ \f' ->
+--       bgroup
+--         ("Replicate Sums: " <> show n)
+--         [ bench "scheduler/replicateConcurrently" $
+--           nfIO $ withScheduler_ Par $ \s -> replicateM_ n $ scheduleWork s $ f' [0 .. elts]
+--         , bench "scheduler/replicateConcurrently" $
+--           nfIO $ replicateConcurrently_ Par n (f' [0 .. elts])
+--         , bench "streamly/replicateM" $
+--           nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' [0 .. elts]
+--         , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' [0 .. elts]
+--         , bench "base/replicateM" $ nfIO $ replicateM n $ f' [0 .. elts]
+--         ]
+--   , env (pure 50000) $ \x ->
+--       bgroup
+--         ("Fib x" <> show n)
+--         [ bench "unliftio/pooledReplicateConcurrently" $
+--           nfIO $ pooledReplicateConcurrently n (newIORef x >>= fibM)
+--         , bench "scheduler/replicateConcurrently" $
+--           nfIO $ replicateConcurrently Par n (newIORef x >>= fibM)
+--         , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n (newFull_ 1000 >>= fibPar)
+--         , bench "streamly/replicateM" $
+--           nfIO $ S.runStream $ asyncly $ S.replicateM n (newIORef x >>= fibM)
+--         , bench "async/replicateConcurrently" $
+--           nfIO $ A.replicateConcurrently n (newIORef x >>= fibM)
+--         , bench "base/replicateM" $ nfIO $ replicateM n (newIORef x >>= fibM)
+--         ]
+--   -- , env (pure fibM) $ \f' ->
+--   --     bgroup
+--   --       ("Fib: " <> show elts)
+--   --       [ bench "scheduler/replicateConcurrently" $ nfIO $ replicateConcurrently Par n $ f' elts
+--   --       , bench "streamly/replicateM" $ nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' elts
+--   --       , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' elts
+--   --       , bench "base/replicateM" $ nfIO $ replicateM n $ f' elts
+--   --       ]
+--   -- , bgroup
+--   --     ("Replicate Discard Sums " <> show n)
+--   --     [ bench "unliftio/pooledReplicateConcurrently_" $
+--   --       nfIO (pooledReplicateConcurrently_ n $ f [0 .. elts])
+--   --     , bench "scheduler/replicateConcurrently_" $
+--   --       nfIO $ replicateConcurrently_ Par n $ f [0 .. elts]
+--   --     , bench "monad-par/replicateM_" $ nfIO $ runParIO $ replicateM_ n $ f [0 .. elts]
+--   --     , bench "async/replicateConcurrently_" $ nfIO $ A.replicateConcurrently_ n $ f [0 .. elts]
+--   --     , bench "streamly/replicateM" $
+--   --       nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
+--   --     ]
+--   , env (pure ls) $ \xs ->
+--       bgroup
+--         ("Sums: " <> show n)
+--         [ bench "unliftio/pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)
+--         , bench "monad-par/parMapM" $ nfIO (runParIO $ parMapM f xs)
+--         , bench "scheduler/traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)
+--         , bench "async/mapConcurrently" $ nfIO (A.mapConcurrently f xs)
+--         , bench "parallel/traverse (par)" $ nfIO (traverse fpar xs)
+--         , bench "base/traverse (seq)" $ nfIO (traverse f xs)
+--         ]
+--   , env (pure ls) $ \xs ->
+--       bgroup
+--         ("Discard Traverse Sums: " <> show n)
+--         [ bgroup "unliftio" [bench "pooledMapConcurrently_" $ nfIO (pooledMapConcurrently_ f xs)]
+--         , bgroup "scheduler" [bench "traverseConcurrently_" $ nfIO (traverseConcurrently_ Par f xs)]
+--         , bgroup "async" [bench "mapConcurrently_" $ nfIO (A.mapConcurrently_ f xs)]
+--         ]
+--   ]
+--   where
+--     ls = replicate n [0 .. elts] :: [[Int]]
+--     f xs =
+--       let ys = F.foldl' (+) 0 xs
+--        in ys `seq` pure ys
+--     fpar xs =
+--       let ys = F.foldl' (+) 0 xs
+--        in ys `par` pure ys

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -1,15 +1,20 @@
 module Main where
 
-import Control.Monad (replicateM_)
-import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)
+import qualified Control.Concurrent.Async as A (mapConcurrently,
+                                                mapConcurrently_,
+                                                replicateConcurrently,
+                                                replicateConcurrently_)
+import Control.Monad (replicateM, replicateM_)
 import Control.Monad.Par (parMapM, runParIO)
 import Control.Parallel (par)
 import Control.Scheduler
 import Criterion.Main
 import Data.Foldable as F
-import UnliftIO.Async (pooledMapConcurrently, pooledMapConcurrently_)
 import Streamly (asyncly)
 import qualified Streamly.Prelude as S
+import UnliftIO.Async (pooledMapConcurrently, pooledMapConcurrently_,
+                       pooledReplicateConcurrently,
+                       pooledReplicateConcurrently_)
 
 
 main :: IO ()
@@ -17,31 +22,54 @@ main = defaultMain (mkSumBench 1000 100000)
 
 mkSumBench :: Int -> Int -> [Benchmark]
 mkSumBench n elts =
-  [ env (pure ls) $ \xs ->
+  [ -- env (pure elts) $ \x ->
+  --     bgroup
+  --       ("Replicate Sums (fast): " <> show x)
+  --       [ bench "unliftio/pooledReplicateConcurrently" $
+  --         nfIO (pooledReplicateConcurrently n $ f [0 .. x])
+  --         --replicateConcurrently Par n $ f [0 .. x]
+  --       , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n $ f [0 .. x]
+  --       ]
+  -- , 
+    env (pure elts) $ \x ->
+      bgroup
+        ("Replicate Sums: " <> show x)
+        [ bench "scheduler/replicateConcurrently" $
+          nfIO $ withScheduler Par $ \s -> replicateM_ n $ scheduleWork s (f [0 .. x])
+        , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f [0 .. x]
+        , bench "streamly/replicateM" $
+          nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 x)
+        , bench "base/replicateM" $ nfIO $ replicateM n $ f [0 .. x]
+        ]
+  -- , bgroup
+  --     ("Replicate Discard Sums " <> show n)
+  --     [ bench "unliftio/pooledReplicateConcurrently_" $
+  --       nfIO (pooledReplicateConcurrently_ n $ f [0 .. elts])
+  --     , bench "scheduler/replicateConcurrently_" $
+  --       nfIO $ replicateConcurrently_ Par n $ f [0 .. elts]
+  --     , bench "monad-par/replicateM_" $ nfIO $ runParIO $ replicateM_ n $ f [0 .. elts]
+  --     , bench "async/replicateConcurrently_" $ nfIO $ A.replicateConcurrently_ n $ f [0 .. elts]
+  --     , bench "streamly/replicateM" $
+  --       nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
+  --     ]
+  , env (pure ls) $ \xs ->
       bgroup
         ("Sums: " <> show n)
-        [ bgroup "unliftio" [bench "pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)]
-        , bgroup "monad-par" [bench "parMapM" $ nfIO (runParIO $ parMapM f xs)]
-        , bgroup "scheduler" [bench "traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)]
-        , bgroup "streamly" [bench "mapM" $ nfIO $ S.runStream $ asyncly $ S.mapM f $ S.fromList xs]
-        , bgroup "async" [bench "mapConcurrently" $ nfIO (mapConcurrently f xs)]
-        , bgroup "base" [bench "traverse . par" $ nfIO (traverse fpar xs)]
-        , bgroup "base" [bench "traverse . seq" $ nfIO (traverse f xs)]
+        [ bench "unliftio/pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)
+        , bench "monad-par/parMapM" $ nfIO (runParIO $ parMapM f xs)
+        , bench "scheduler/traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)
+        , bench "streamly/mapM" $ nfIO $ S.runStream $ asyncly $ S.mapM f $ S.fromList xs
+        , bench "async/mapConcurrently" $ nfIO (A.mapConcurrently f xs)
+        , bench "parallel/traverse (par)" $ nfIO (traverse fpar xs)
+        , bench "base/traverse (seq)" $ nfIO (traverse f xs)
         ]
   , env (pure ls) $ \xs ->
       bgroup
-        ("Discard Sums: " <> show n)
+        ("Discard Traverse Sums: " <> show n)
         [ bgroup "unliftio" [bench "pooledMapConcurrently_" $ nfIO (pooledMapConcurrently_ f xs)]
         , bgroup "scheduler" [bench "traverseConcurrently_" $ nfIO (traverseConcurrently_ Par f xs)]
-        , bgroup "async" [bench "mapConcurrently_" $ nfIO (mapConcurrently_ f xs)]
+        , bgroup "async" [bench "mapConcurrently_" $ nfIO (A.mapConcurrently_ f xs)]
         ]
-  , bgroup
-      "NoList"
-      [ bench "scheduler" $
-        nfIO $ withScheduler Par $ \s -> replicateM_ n $ scheduleWork s $ f [0 .. elts]
-      , bench "streamly" $
-        nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
-      ]
   ]
   where
     ls = replicate n [0 .. elts] :: [[Int]]

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -1,140 +1,103 @@
 module Main where
 
-import qualified Control.Concurrent.Async as A (mapConcurrently,
-                                                mapConcurrently_,
-                                                replicateConcurrently,
-                                                replicateConcurrently_)
-import Control.Monad (replicateM, replicateM_)
+import qualified Control.Concurrent.Async as A (mapConcurrently, replicateConcurrently)
+import Control.Monad (replicateM)
 import Control.Monad.Par (IVar, Par, get, newFull_, parMapM, runParIO)
 import Control.Parallel (par)
 import Control.Scheduler
 import Criterion.Main
+import Control.DeepSeq
 import Data.Foldable as F
 import Data.IORef
 import Fib
 import Streamly (asyncly)
 import qualified Streamly.Prelude as S
-import UnliftIO.Async (pooledMapConcurrently, pooledMapConcurrently_,
-                       pooledReplicateConcurrently,
-                       pooledReplicateConcurrently_)
+import UnliftIO.Async (pooledMapConcurrently, pooledReplicateConcurrently)
 
 main :: IO ()
 main = do
-  defaultMain ([mkFibBench n x | n <- [100], x <- [100]]) --, 1000, 10000], x <- [100, 1000, 10000]])
+  defaultMain
+    ([mkBenchReplicate "Fib" n x fibIORef fibParVar | n <- [1000], x <- [10000]] ++
+     [mkBenchReplicate "Sum" n x sumIORef sumParVar | n <- [1000], x <- [1000]] ++
+     [mkBenchMap "Fib" n fibIO fibParIO fibPar | n <- [2000]] ++
+     [mkBenchMap "Sum" n sumIO sumParIO sumPar | n <- [2000]])
+  where
+    fibIO :: Int -> IO Integer
+    fibIO x = do
+      let y = fib $ toInteger x
+      y `seq` pure y
+    fibParIO :: Int -> IO Integer
+    fibParIO x = do
+      let y = fib $ toInteger x
+      y `par` pure y
+    fibPar :: Int -> Par Integer
+    fibPar x = do
+      let y = fib $ toInteger x
+      y `seq` pure y
+    sumIO :: Int -> IO Int
+    sumIO x = do
+      let y = F.foldl' (+) 0 [x .. 100*x]
+      y `seq` pure y
+    sumParIO :: Int -> IO Int
+    sumParIO x = do
+      let y = F.foldl' (+) 0 [x .. 100*x]
+      y `par` pure y
+    sumPar :: Int -> Par Int
+    sumPar x = do
+      let y = F.foldl' (+) 0 [x .. 100*x]
+      y `seq` pure y
+    fibIORef :: IORef Int -> IO Integer
+    fibIORef xRef = readIORef xRef >>= fibIO
+    fibParVar :: IVar Int -> Par Integer
+    fibParVar ivar = get ivar >>= fibPar
+    sumIORef :: IORef Int -> IO Int
+    sumIORef xRef = readIORef xRef >>= sumIO
+    sumParVar :: IVar Int -> Par Int
+    sumParVar ivar = get ivar >>= sumPar
 
-mkFibBench ::
-     Int -- ^ Number of workers
-  -> Int -- ^ Fibbonacci number
+mkBenchReplicate ::
+     NFData a
+  => String
+  -> Int -- ^ Number of tasks
+  -> Int -- ^ Opaque Int a function should be applied to
+  -> (IORef Int -> IO a)
+  -> (IVar Int -> Par a)
   -> Benchmark
-mkFibBench n x =
+mkBenchReplicate name n x fxIO fxPar =
   bgroup
-    ("Fib " <> show x)
-    [ bench ("unliftio/pooledReplicateConcurrently" ++ nStr) $
-      nfIO $ pooledReplicateConcurrently n (newIORef x >>= fibM)
-    , bench ("scheduler/replicateConcurrently" ++ nStr) $
-      nfIO $ replicateConcurrently Par n (newIORef x >>= fibM)
-    , bench ("streamly/replicateM" ++ nStr) $
-      nfIO $ S.runStream $ asyncly $ S.replicateM n (newIORef x >>= fibM)
-    , bench ("monad-par/replicateM" ++ nStr) $
-      nfIO $ runParIO $ replicateM n (newFull_ x >>= fibPar)
-    , bench ("async/replicateConcurrently" ++ nStr) $
-      nfIO $ A.replicateConcurrently n (newIORef x >>= fibM)
-    , bench ("base/replicateM" ++ nStr) $ nfIO $ replicateM n (newIORef x >>= fibM)
+    ("replicate/" <> name <> str)
+    [ bench "scheduler/replicateConcurrently" $
+      nfIO $ replicateConcurrently Par n (newIORef x >>= fxIO)
+    , bench "unliftio/pooledReplicateConcurrently" $
+      nfIO $ pooledReplicateConcurrently n (newIORef x >>= fxIO)
+    , bench "streamly/replicateM" $
+      nfIO $ S.runStream $ asyncly $ S.replicateM n (newIORef x >>= fxIO)
+    , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n (newIORef x >>= fxIO)
+    , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n (newFull_ x >>= fxPar)
+    , bench "base/replicateM" $ nfIO $ replicateM n (newIORef x >>= fxIO)
     ]
   where
-    nStr = " (" ++ show n ++ ")"
-    fibM :: IORef Int -> IO Integer
-    fibM xRef = do
-      x' <- readIORef xRef
-      let y = fib $ toInteger x'
-      y `seq` pure y
-    fibPar :: IVar Int -> Par Integer
-    fibPar ivar = do
-      x' <- get ivar
-      let y = fib $ toInteger x'
-      y `seq` pure y
+    str = "(" ++ show n ++ "/" ++ show x ++ ")"
 
 
--- mkSumBench :: Int -> Int -> [Benchmark]
--- mkSumBench n elts
---     -- env (pure elts) $ \x ->
---   --     bgroup
---   --       ("Replicate Sums (fast): " <> show x)
---   --       [ bench "unliftio/pooledReplicateConcurrently" $
---   --         nfIO (pooledReplicateConcurrently n $ f [0 .. x])
---   --         --replicateConcurrently Par n $ f [0 .. x]
---   --       , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n $ f [0 .. x]
---   --       ]
---   -- ,
---  =
---   [ env (pure f) $ \f' ->
---       bgroup
---         ("Replicate Sums: " <> show n)
---         [ bench "scheduler/replicateConcurrently" $
---           nfIO $ withScheduler_ Par $ \s -> replicateM_ n $ scheduleWork s $ f' [0 .. elts]
---         , bench "scheduler/replicateConcurrently" $
---           nfIO $ replicateConcurrently_ Par n (f' [0 .. elts])
---         , bench "streamly/replicateM" $
---           nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' [0 .. elts]
---         , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' [0 .. elts]
---         , bench "base/replicateM" $ nfIO $ replicateM n $ f' [0 .. elts]
---         ]
---   , env (pure 50000) $ \x ->
---       bgroup
---         ("Fib x" <> show n)
---         [ bench "unliftio/pooledReplicateConcurrently" $
---           nfIO $ pooledReplicateConcurrently n (newIORef x >>= fibM)
---         , bench "scheduler/replicateConcurrently" $
---           nfIO $ replicateConcurrently Par n (newIORef x >>= fibM)
---         , bench "monad-par/replicateM" $ nfIO $ runParIO $ replicateM n (newFull_ 1000 >>= fibPar)
---         , bench "streamly/replicateM" $
---           nfIO $ S.runStream $ asyncly $ S.replicateM n (newIORef x >>= fibM)
---         , bench "async/replicateConcurrently" $
---           nfIO $ A.replicateConcurrently n (newIORef x >>= fibM)
---         , bench "base/replicateM" $ nfIO $ replicateM n (newIORef x >>= fibM)
---         ]
---   -- , env (pure fibM) $ \f' ->
---   --     bgroup
---   --       ("Fib: " <> show elts)
---   --       [ bench "scheduler/replicateConcurrently" $ nfIO $ replicateConcurrently Par n $ f' elts
---   --       , bench "streamly/replicateM" $ nfIO $ S.runStream $ asyncly $ S.replicateM n $ f' elts
---   --       , bench "async/replicateConcurrently" $ nfIO $ A.replicateConcurrently n $ f' elts
---   --       , bench "base/replicateM" $ nfIO $ replicateM n $ f' elts
---   --       ]
---   -- , bgroup
---   --     ("Replicate Discard Sums " <> show n)
---   --     [ bench "unliftio/pooledReplicateConcurrently_" $
---   --       nfIO (pooledReplicateConcurrently_ n $ f [0 .. elts])
---   --     , bench "scheduler/replicateConcurrently_" $
---   --       nfIO $ replicateConcurrently_ Par n $ f [0 .. elts]
---   --     , bench "monad-par/replicateM_" $ nfIO $ runParIO $ replicateM_ n $ f [0 .. elts]
---   --     , bench "async/replicateConcurrently_" $ nfIO $ A.replicateConcurrently_ n $ f [0 .. elts]
---   --     , bench "streamly/replicateM" $
---   --       nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
---   --     ]
---   , env (pure ls) $ \xs ->
---       bgroup
---         ("Sums: " <> show n)
---         [ bench "unliftio/pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)
---         , bench "monad-par/parMapM" $ nfIO (runParIO $ parMapM f xs)
---         , bench "scheduler/traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)
---         , bench "async/mapConcurrently" $ nfIO (A.mapConcurrently f xs)
---         , bench "parallel/traverse (par)" $ nfIO (traverse fpar xs)
---         , bench "base/traverse (seq)" $ nfIO (traverse f xs)
---         ]
---   , env (pure ls) $ \xs ->
---       bgroup
---         ("Discard Traverse Sums: " <> show n)
---         [ bgroup "unliftio" [bench "pooledMapConcurrently_" $ nfIO (pooledMapConcurrently_ f xs)]
---         , bgroup "scheduler" [bench "traverseConcurrently_" $ nfIO (traverseConcurrently_ Par f xs)]
---         , bgroup "async" [bench "mapConcurrently_" $ nfIO (A.mapConcurrently_ f xs)]
---         ]
---   ]
---   where
---     ls = replicate n [0 .. elts] :: [[Int]]
---     f xs =
---       let ys = F.foldl' (+) 0 xs
---        in ys `seq` pure ys
---     fpar xs =
---       let ys = F.foldl' (+) 0 xs
---        in ys `par` pure ys
+mkBenchMap ::
+     NFData a
+  => String
+  -> Int -- ^ Number of tasks
+  -> (Int -> IO a)
+  -> (Int -> IO a)
+  -> (Int -> Par a)
+  -> Benchmark
+mkBenchMap name n fxIO fxParIO fxPar =
+  bgroup
+    ("map/" <> name <> str)
+    [ bench "scheduler/traverseConcurrently" $ nfIO $ traverseConcurrently Par fxIO [1 .. n]
+    , bench "unliftio/pooledTraverseConcurrently" $ nfIO $ pooledMapConcurrently fxIO [1 .. n]
+    , bench "streamly/mapM" $ nfIO $ S.runStream $ asyncly $ S.mapM fxIO $ S.enumerateFromTo 1 n
+    , bench "async/mapConcurrently" $ nfIO $ A.mapConcurrently fxIO [1 .. n]
+    , bench "par/mapM" $ nfIO $ mapM fxParIO [1 .. n]
+    , bench "monad-par/mapM" $ nfIO $ runParIO $ mapM fxPar [1 .. n]
+    , bench "base/mapM" $ nfIO $ mapM fxIO [1 .. n]
+    ]
+  where
+    str = "(" ++ show n ++ ")"

--- a/scheduler/bench/Scheduler.hs
+++ b/scheduler/bench/Scheduler.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE BangPatterns #-}
 module Main where
 
+import Control.Monad (void)
 import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)
 import Control.Monad.Par (parMapM, runParIO)
 import Control.Parallel (par)
-import Control.Scheduler (Comp(Par), traverseConcurrently, traverseConcurrently_)
+import Control.Scheduler
 import Criterion.Main
 import Data.Foldable as F
 import UnliftIO.Async (pooledMapConcurrently, pooledMapConcurrently_)
@@ -12,30 +14,50 @@ import qualified Streamly.Prelude as S
 
 
 main :: IO ()
-main = defaultMain (mkSumBench 1000)
+main = defaultMain (mkSumBench 1000 100000)
 
-mkSumBench :: Int -> [Benchmark]
-mkSumBench n =
+mkSumBench :: Int -> Int -> [Benchmark]
+mkSumBench n elts =
   [ env (pure ls) $ \xs ->
       bgroup
         ("Sums: " <> show n)
         [ bgroup "unliftio" [bench "pooledMapConcurrently" $ nfIO (pooledMapConcurrently f xs)]
         , bgroup "monad-par" [bench "parMapM" $ nfIO (runParIO $ parMapM f xs)]
         , bgroup "scheduler" [bench "traverseConcurrently" $ nfIO (traverseConcurrently Par f xs)]
+        , bgroup "streamly" [bench "mapM" $ nfIO $ S.runStream $ asyncly $ S.mapM f $ S.fromList xs]
         , bgroup "async" [bench "mapConcurrently" $ nfIO (mapConcurrently f xs)]
         , bgroup "base" [bench "traverse . par" $ nfIO (traverse fpar xs)]
         , bgroup "base" [bench "traverse . seq" $ nfIO (traverse f xs)]
         ]
-  , bench "streamly" $ nfIO $
-        S.runStream $ asyncly $
-            S.replicateM n (fstreamly $ S.enumerateFromTo 0 (100000 :: Int))
+  , env (pure ls) $ \xs ->
+      bgroup
+        ("Discard Sums: " <> show n)
+        [ bgroup "unliftio" [bench "pooledMapConcurrently_" $ nfIO (pooledMapConcurrently_ f xs)]
+        , bgroup "scheduler" [bench "traverseConcurrently_" $ nfIO (traverseConcurrently_ Par f xs)]
+        , bgroup "async" [bench "mapConcurrently" $ nfIO (mapConcurrently_ f xs)]
+        ]
+  , bgroup
+      "NoList"
+      [ bench "scheduler" $
+        nfIO $ withScheduler_ Par $ \s -> loopM_ n $ scheduleWork s $ void $ f [0 .. elts]
+      , bench "streamly" $
+        nfIO $ S.runStream $ asyncly $ S.replicateM n (fstreamly $ S.enumerateFromTo 0 elts)
+      ]
   ]
   where
-    ls = replicate n [0 .. 100000] :: [[Int]]
+    ls = replicate n [0 .. elts] :: [[Int]]
     f xs =
       let ys = F.foldl' (+) 0 xs
        in ys `seq` pure ys
     fpar xs =
       let ys = F.foldl' (+) 0 xs
        in ys `par` pure ys
-    fstreamly xs = S.foldl' (+) 0 xs
+    fstreamly = S.foldl' (+) 0
+
+
+loopM_ :: Monad m => Int -> m a -> m ()
+loopM_ n f = go 0
+  where
+    go !i
+      | i < n = f >> go (i + 1)
+      | otherwise = pure ()

--- a/scheduler/scheduler.cabal
+++ b/scheduler/scheduler.cabal
@@ -80,4 +80,4 @@ benchmark scheduler
 
 source-repository head
   type:     git
-  location: https://github.com/lehins/massiv
+  location: https://github.com/lehins/haskell-scheduler

--- a/scheduler/scheduler.cabal
+++ b/scheduler/scheduler.cabal
@@ -71,6 +71,7 @@ benchmark scheduler
                      , async
                      , criterion
                      , deepseq
+                     , fib
                      , monad-par
                      , scheduler
                      , parallel

--- a/scheduler/src/Control/Scheduler.hs
+++ b/scheduler/src/Control/Scheduler.hs
@@ -238,7 +238,6 @@ withSchedulerInternal comp submitWork collect onScheduler = do
               catch
                 (unmask $ run $ runWorker jobsQueue onRetire)
                 (run . handleWorkerException jobsQueue workDoneMVar jobsNumWorkers)
-      --{-# INLINE spawnWorkersWith #-}
       spawnWorkers =
         case comp of
           Seq -> return []
@@ -246,7 +245,6 @@ withSchedulerInternal comp submitWork collect onScheduler = do
           Par -> spawnWorkersWith forkOnWithUnmask [1 .. jobsNumWorkers]
           ParOn ws -> spawnWorkersWith forkOnWithUnmask ws
           ParN _ -> spawnWorkersWith (\_ -> forkIOWithUnmask) [1 .. jobsNumWorkers]
-      --{-# INLINE spawnWorkers #-}
       doWork = do
         when (comp == Seq) $ runWorker jobsQueue onRetire
         mExc <- liftIO $ readMVar workDoneMVar
@@ -259,7 +257,6 @@ withSchedulerInternal comp submitWork collect onScheduler = do
           Just (WorkerException exc) -> liftIO $ throwIO exc
           -- \ Here we need to unwrap the legit worker exception and rethrow it, so the main thread
           -- will think like it's his own
-      --{-# INLINE doWork #-}
   safeBracketOnError
     spawnWorkers
     (liftIO . traverse_ (`throwTo` SomeAsyncException WorkerTerminateException))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
-resolver: lts-12.26
+resolver: lts-13.15
 packages:
 - 'scheduler/'
 extra-deps:
 - unliftio-0.2.10@sha256:ed8bc7f9c38361aebd5481efbbbe6e3ee9468d07fffd1a7f0670f0fbbe28bb4f
 - streamly-0.6.1
+- fib-0.1@sha256:908695e8f5089f0b9ad05ba663a407c269c0553e9cd913a64f1b2543238427de
+# - base-noprelude-4.12.0.0@sha256:dcd5ece10257f79fa16e207d558b31ab3467b205adae5d1976abdee28b1c8b4a
+- semirings-0.3.1.1@sha256:0e07826f31ae276821bb1e3397ca11ffb4cfb0cc0a9903e2dc029385fe54dd6d


### PR DESCRIPTION
This is the adjustment for benchmarks from #1 

@harendra-kumar Point of the original benchmark was to see how fast we can monadically traverse the list of tasks in order to see how well the scheduling works in each individual library. Basically a simulation of a `1000` tasks, where each task is something computationally intensive like a sum of a list first `100000` integers.

The benchmarks that you added as part of #1 totally avoids the list structure, as such it doesn't compare directly to other libraries. That is why you had such a speed up.

I added a benchmark that does something a lot more similar to what you achieve with `streamly` (by the way pretty cool library), namely looks at each task individually in a loop, rather than iterating over a list. Here is a sample run on  my laptop:
```
benchmarking NoList/scheduler
time                 16.09 ms   (15.87 ms .. 16.32 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 16.02 ms   (15.81 ms .. 16.32 ms)
std dev              549.1 μs   (394.6 μs .. 836.7 μs)
variance introduced by outliers: 12% (moderately inflated)
                             
benchmarking NoList/streamly 
time                 26.02 ms   (25.76 ms .. 26.29 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 25.92 ms   (25.68 ms .. 26.23 ms)
std dev              570.7 μs   (393.5 μs .. 797.0 μs)
```

