### PR TITLE
New function: `replicateWork`

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.1
+
+* Add functions: `replicateWork`
+
 # 1.4.0
 
 * Worker id has been promoted from `Int` to a `newtype` wrapper `WorkerId`.

--- a/scheduler/scheduler.cabal
+++ b/scheduler/scheduler.cabal
@@ -1,5 +1,5 @@
 name:                scheduler
-version:             1.4.0
+version:             1.4.1
 synopsis:            Work stealing scheduler.
 description:         A work stealing scheduler that is primarly developed for [massiv](https://github.com/lehins/massiv) array librarry, but it is general enough to be useful for any computation that fits the model of few workers many jobs.
 homepage:            https://github.com/lehins/haskell-scheduler

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
-resolver: lts-13.15
+resolver: lts-13.27
+
 packages:
-- 'scheduler/'
+  - 'scheduler/'
+
 extra-deps:
-- unliftio-0.2.10@sha256:ed8bc7f9c38361aebd5481efbbbe6e3ee9468d07fffd1a7f0670f0fbbe28bb4f
-- streamly-0.6.1
-- fib-0.1@sha256:908695e8f5089f0b9ad05ba663a407c269c0553e9cd913a64f1b2543238427de
-# - base-noprelude-4.12.0.0@sha256:dcd5ece10257f79fa16e207d558b31ab3467b205adae5d1976abdee28b1c8b4a
-- semirings-0.3.1.1@sha256:0e07826f31ae276821bb1e3397ca11ffb4cfb0cc0a9903e2dc029385fe54dd6d
+  - fib-0.1@sha256:908695e8f5089f0b9ad05ba663a407c269c0553e9cd913a64f1b2543238427de,930
+  - semirings-0.4.2@sha256:7803a3bd8add49c375da59d456b59e32ea02a88ac1a1d71132420e4c976333f3,3750
+  - streamly-0.6.1@sha256:5c8501ffc49cb55563fbdb3e971d66a75b628ee4a9db2d93f108ec1ea961347a,25103


### PR DESCRIPTION
```haskell
-- | Schedule the same action to run @n@ times concurrently. This differs from
-- `replicateConcurrently` by allowing the caller to use the `Scheduler` freely,
-- or to allow early termination via `terminate` across all (identical) threads.
-- To be called within a `withScheduler` block.
--
-- @since 1.4.1
replicateWork :: Applicative m => Int -> Scheduler m a -> m a -> m ()
replicateWork !n scheduler f
  | n <= 0 = pure ()
  | otherwise = scheduleWork scheduler f *> replicateWork (pred n) scheduler f
```
The `Applicative` constraint isn't so nice, but apparently unavoidable.

This would induce a version bump to `1.4.1`.